### PR TITLE
Fixing the error to ensure the code runs correctly

### DIFF
--- a/destination/urls.py
+++ b/destination/urls.py
@@ -8,5 +8,4 @@ urlpatterns = [
     path("search/", views.search_municipalities, name="search_municipalities"),
     path('municipalities/<int:municipality_id>/events/', views.event_calendar, name='municipality_events'),
     path('', views.home, name='home'),
-    path("__reload__/", include("django_browser_reload.urls")),
 ]


### PR DESCRIPTION
Fixed a duplicate route issue in the URLs configuration. There were two instances of path("__reload__/", include("django_browser_reload.urls")), one in destinations and another in the main configuration. The duplicate in destinations was removed to prevent conflicts in route resolution.